### PR TITLE
feat(CAF-1094): Add toggle for public routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ module "vpc_cidr_from_ipam" {
 }
 ```
 
+## Disable default route creation for public subnets
+
+ Disabling the creation of the default route is useful if you want the default route to point to gateways other than the Internet Gateway (IGW).
+
 ## Examples
 
 - [Complete VPC](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/complete) with VPC Endpoints.

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ module "vpc_cidr_from_ipam" {
 
  Disabling the creation of the default route is useful if you want the default route to point to gateways other than the Internet Gateway (IGW).
 
+ You disable the creation by setting the var.public_enable_default_route variable ex.
+
+```hcl
+  public_disable_default_route = false  # <= By default it is true to maintain existing behavior
+```
+
 ## Examples
 
 - [Complete VPC](https://github.com/terraform-aws-modules/terraform-aws-vpc/tree/master/examples/complete) with VPC Endpoints.

--- a/main.tf
+++ b/main.tf
@@ -186,7 +186,7 @@ resource "aws_route_table_association" "public" {
 }
 
 resource "aws_route" "public_internet_gateway" {
-  count = local.create_public_subnets && var.create_igw ? local.num_public_route_tables : 0
+  count = alltrue([local.create_public_subnets, var.create_igw, var.public_enable_default_route]) ? local.num_public_route_tables : 0
 
   route_table_id         = aws_route_table.public[count.index].id
   destination_cidr_block = "0.0.0.0/0"
@@ -198,7 +198,7 @@ resource "aws_route" "public_internet_gateway" {
 }
 
 resource "aws_route" "public_internet_gateway_ipv6" {
-  count = local.create_public_subnets && var.create_igw && var.enable_ipv6 ? local.num_public_route_tables : 0
+  count = alltrue([local.create_public_subnets, var.create_igw, var.enable_ipv6, var.public_enable_default_route]) ? local.num_public_route_tables : 0
 
   route_table_id              = aws_route_table.public[count.index].id
   destination_ipv6_cidr_block = "::/0"

--- a/variables.tf
+++ b/variables.tf
@@ -274,6 +274,12 @@ variable "public_route_table_tags" {
   default     = {}
 }
 
+variable "public_enable_default_route" {
+  description = "Disable default route to internet gateway for public subnets"
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # Public Network ACLs
 ################################################################################


### PR DESCRIPTION
Disabling the creation of the default can be used if you want have a default pointing to other gateways than the internet gateway(IGW)

This is useful if you ex. would want to route all traffic through a AWS Network Firewall, but can also be useful for other purposes

