### PR TITLE
feat(CAF-1006): add toggle for default public route creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ This is useful if you ex. would want to route all traffic through a AWS Network 
 You disable the creation by setting the var.public_enable_default_route variable ex.
 
 ```hcl
-  public_disable_default_route = false  # <= By default it is true to maintain existing behavior
+  public_enable_default_route = false  # <= By default it is true to maintain existing behavior
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -228,6 +228,17 @@ module "vpc_cidr_from_ipam" {
   public_subnets    = local.public_subnets
 }
 ```
+## Disable default route creation for public subnets
+
+Disabling the creation of the default can be used if you want have a default pointing to other gateways than the internet gateway(IGW)
+
+This is useful if you ex. would want to route all traffic through a AWS Network Firewall, but can also be useful for other purposes
+
+You disable the creation by setting the var.public_enable_default_route variable ex.
+
+```hcl
+  public_disable_default_route = false  # <= By default it is true to maintain existing behavior
+```
 
 ## Examples
 

--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,7 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route_table_association" "public" {
-  count = local.create_public_subnets ? local.len_public_subnets : 0
+  count = var.create_public_route_association && local.create_public_subnets ? local.len_public_subnets : 0
 
   subnet_id      = element(aws_subnet.public[*].id, count.index)
   route_table_id = element(aws_route_table.public[*].id, var.create_multiple_public_route_tables ? count.index : 0)

--- a/main.tf
+++ b/main.tf
@@ -186,7 +186,7 @@ resource "aws_route_table_association" "public" {
 }
 
 resource "aws_route" "public_internet_gateway" {
-  count = local.create_public_subnets && var.create_igw ? local.num_public_route_tables : 0
+  count = alltrue([local.create_public_subnets, var.create_igw, var.public_enable_default_route]) ? local.num_public_route_tables : 0
 
   route_table_id         = aws_route_table.public[count.index].id
   destination_cidr_block = "0.0.0.0/0"
@@ -198,7 +198,7 @@ resource "aws_route" "public_internet_gateway" {
 }
 
 resource "aws_route" "public_internet_gateway_ipv6" {
-  count = local.create_public_subnets && var.create_igw && var.enable_ipv6 ? local.num_public_route_tables : 0
+  count = alltrue([local.create_public_subnets, var.create_igw, var.enable_ipv6, var.public_enable_default_route]) ? local.num_public_route_tables : 0
 
   route_table_id              = aws_route_table.public[count.index].id
   destination_ipv6_cidr_block = "::/0"

--- a/variables.tf
+++ b/variables.tf
@@ -274,6 +274,12 @@ variable "public_route_table_tags" {
   default     = {}
 }
 
+variable "public_enable_default_route" {
+  description = "Disable default route to internet gateway for public subnets"
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # Public Network ACLs
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -280,6 +280,12 @@ variable "public_enable_default_route" {
   default     = true
 }
 
+variable "create_public_route_association" {
+  description = "Option to associate public route tables"
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # Public Network ACLs
 ################################################################################


### PR DESCRIPTION
JIRA: CAF-1094

Disabling the creation of the default can be used if you want have a default pointing to other gateways than the internet gateway(IGW)

This is useful if you ex. would want to route all traffic through a AWS Network Firewall, but can also be useful for other purposes